### PR TITLE
feat: add "route eggs" setting to default extension config controller

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+    "printWidth": 120,
+    "tabWidth": 2,
+    "useTabs": false,
+    "semi": true,
+    "singleQuote": true,
+    "jsxSingleQuote": true,
+    "endOfLine": "lf"
+}

--- a/app/BlueprintFramework/Controllers/ExtensionConfigurationController.php
+++ b/app/BlueprintFramework/Controllers/ExtensionConfigurationController.php
@@ -20,7 +20,23 @@ class ExtensionConfigurationController extends Controller
    */
   public function update(ExtensionConfigurationRequest $request): RedirectResponse
   {
-    foreach ($request->normalize() as $key => $value) { $this->settings->set('blueprint::extensionconfig_' . $key, $value); }
+    // set extension eggs to be -1 (Show all), then overwrite if needed
+    $this->settings->set('blueprint::extensionconfig_' . $request->input('_identifier', 'blueprint') . '_eggs', '["-1"]');
+
+    foreach ($request->normalize() as $key => $value) {
+      if (str_ends_with($key, '_eggs')) {
+        // if there are other eggs set, remove the -1 'egg'
+        $eggs = (array)$value['*'];
+        if (count($eggs) > 1 && in_array('-1', $eggs)) {
+          $eggs = array_diff($eggs, ['-1']);
+        }
+
+        $value = json_encode(array_values($eggs));
+      }
+
+      $this->settings->set('blueprint::extensionconfig_' . $key, $value);
+    }
+  
     return redirect()->route('admin.extensions.'.$request->input('_identifier', 'blueprint').'.index');
   }
 }
@@ -31,6 +47,8 @@ class ExtensionConfigurationRequest extends AdminFormRequest
     return [
       $this->input('_identifier', 'blueprint').'_adminlayouts' => 'boolean',
       $this->input('_identifier', 'blueprint').'_dashboardwrapper' => 'boolean',
+      $this->input('_identifier', 'blueprint').'_eggs' => 'array',
+      $this->input('_identifier', 'blueprint').'_eggs.*' => 'numeric',
     ];
   }
 

--- a/app/BlueprintFramework/Controllers/ExtensionRouteController.php
+++ b/app/BlueprintFramework/Controllers/ExtensionRouteController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Pterodactyl\BlueprintFramework\Controllers;
+
+use Pterodactyl\Http\Requests\Api\Client\ClientApiRequest;
+use Pterodactyl\Http\Controllers\Api\Client\ClientApiController;
+use Pterodactyl\Contracts\Repository\SettingsRepositoryInterface;
+
+class ExtensionRouteController extends ClientApiController
+{
+    public function __construct(
+        private SettingsRepositoryInterface $settings,
+    ) {
+        parent::__construct();
+    }
+
+    public function eggs(GetRouteEggsRequest $request): array
+    {
+        $id = $request->input('id', 'blueprint');
+        $eggs = $this->settings->get('blueprint::extensionconfig_' . $id . '_eggs');
+        return json_decode($eggs ?: '["-1"]');
+    }
+}
+
+class GetRouteEggsRequest extends ClientApiRequest {
+    public function authorize(): bool
+    {
+        return true;
+    }
+}

--- a/app/Http/Controllers/Admin/Extensions/Blueprint/BlueprintExtensionController.php
+++ b/app/Http/Controllers/Admin/Extensions/Blueprint/BlueprintExtensionController.php
@@ -2,9 +2,9 @@
 
 namespace Pterodactyl\Http\Controllers\Admin\Extensions\Blueprint;
 
+use Artisan;
 use Illuminate\View\View;
 use Illuminate\View\Factory as ViewFactory;
-use Artisan;
 use Pterodactyl\Http\Controllers\Controller;
 use Pterodactyl\BlueprintFramework\Services\PlaceholderService\BlueprintPlaceholderService;
 use Pterodactyl\BlueprintFramework\Services\ConfigService\BlueprintConfigService;

--- a/blueprint/extensions/blueprint/private/build/extensions/controller.build
+++ b/blueprint/extensions/blueprint/private/build/extensions/controller.build
@@ -3,6 +3,7 @@
 namespace Pterodactyl\Http\Controllers\Admin\Extensions\[id];
 
 use Illuminate\View\View;
+use Pterodactyl\Models\Egg;
 use Illuminate\View\Factory as ViewFactory;
 use Pterodactyl\Http\Controllers\Controller;
 use Pterodactyl\Services\Helpers\SoftwareVersionService;
@@ -29,6 +30,7 @@ class [id]ExtensionController extends Controller
     return $this->view->make('admin.extensions.[id].index', [
       'blueprint' => $this->blueprint,
       'version' => $this->version,
+      'eggs' => Egg::all(),
       'root' => $rootPath
     ]);
   }

--- a/resources/scripts/api/server/getServer.ts
+++ b/resources/scripts/api/server/getServer.ts
@@ -3,91 +3,94 @@ import { rawDataToServerAllocation, rawDataToServerEggVariable } from '@/api/tra
 import { ServerEggVariable, ServerStatus } from '@/api/server/types';
 
 export interface Allocation {
-    id: number;
-    ip: string;
-    alias: string | null;
-    port: number;
-    notes: string | null;
-    isDefault: boolean;
+  id: number;
+  ip: string;
+  alias: string | null;
+  port: number;
+  notes: string | null;
+  isDefault: boolean;
 }
 
 export interface Server {
-    id: string;
-    internalId: number | string;
-    uuid: string;
-    name: string;
-    node: string;
-    isNodeUnderMaintenance: boolean;
-    status: ServerStatus;
-    sftpDetails: {
-        ip: string;
-        port: number;
-    };
-    invocation: string;
-    dockerImage: string;
-    description: string;
-    limits: {
-        memory: number;
-        swap: number;
-        disk: number;
-        io: number;
-        cpu: number;
-        threads: string;
-    };
-    eggFeatures: string[];
-    featureLimits: {
-        databases: number;
-        allocations: number;
-        backups: number;
-    };
-    isTransferring: boolean;
-    variables: ServerEggVariable[];
-    allocations: Allocation[];
-    
-    BlueprintFramework: {
-        eggId: number;
-    };
+  id: string;
+  internalId: number | string;
+  uuid: string;
+  name: string;
+  node: string;
+  isNodeUnderMaintenance: boolean;
+  status: ServerStatus;
+  sftpDetails: {
+    ip: string;
+    port: number;
+  };
+  invocation: string;
+  dockerImage: string;
+  description: string;
+  limits: {
+    memory: number;
+    swap: number;
+    disk: number;
+    io: number;
+    cpu: number;
+    threads: string;
+  };
+  eggFeatures: string[];
+  featureLimits: {
+    databases: number;
+    allocations: number;
+    backups: number;
+  };
+  isTransferring: boolean;
+  variables: ServerEggVariable[];
+  allocations: Allocation[];
+
+  BlueprintFramework: {
+    eggId: number;
+  };
 }
 
 export const rawDataToServerObject = ({ attributes: data }: FractalResponseData): Server => ({
-    id: data.identifier,
-    internalId: data.internal_id,
-    uuid: data.uuid,
-    name: data.name,
-    node: data.node,
-    isNodeUnderMaintenance: data.is_node_under_maintenance,
-    status: data.status,
-    invocation: data.invocation,
-    dockerImage: data.docker_image,
-    sftpDetails: {
-        ip: data.sftp_details.ip,
-        port: data.sftp_details.port,
-    },
-    description: data.description ? (data.description.length > 0 ? data.description : null) : null,
-    limits: { ...data.limits },
-    eggFeatures: data.egg_features || [],
-    featureLimits: { ...data.feature_limits },
-    isTransferring: data.is_transferring,
-    variables: ((data.relationships?.variables as FractalResponseList | undefined)?.data || []).map(
-        rawDataToServerEggVariable
-    ),
-    allocations: ((data.relationships?.allocations as FractalResponseList | undefined)?.data || []).map(
-        rawDataToServerAllocation
-    ),
+  id: data.identifier,
+  internalId: data.internal_id,
+  uuid: data.uuid,
+  name: data.name,
+  node: data.node,
+  isNodeUnderMaintenance: data.is_node_under_maintenance,
+  status: data.status,
+  invocation: data.invocation,
+  dockerImage: data.docker_image,
+  sftpDetails: {
+    ip: data.sftp_details.ip,
+    port: data.sftp_details.port,
+  },
+  description: data.description ? (data.description.length > 0 ? data.description : null) : null,
+  limits: { ...data.limits },
+  eggFeatures: data.egg_features || [],
+  featureLimits: { ...data.feature_limits },
+  isTransferring: data.is_transferring,
+  variables: ((data.relationships?.variables as FractalResponseList | undefined)?.data || []).map(
+    rawDataToServerEggVariable
+  ),
+  allocations: ((data.relationships?.allocations as FractalResponseList | undefined)?.data || []).map(
+    rawDataToServerAllocation
+  ),
 
-    BlueprintFramework: { ...data.BlueprintFramework }
+  BlueprintFramework: {
+    eggId: data.BlueprintFramework.egg_id,
+  },
 });
 
 export default (uuid: string): Promise<[Server, string[]]> => {
-    return new Promise((resolve, reject) => {
-        http.get(`/api/client/servers/${uuid}`)
-            .then(({ data }) =>
-                resolve([
-                    rawDataToServerObject(data),
-                    // eslint-disable-next-line camelcase
-                    data.meta?.is_server_owner ? ['*'] : data.meta?.user_permissions || [],
-                ])
-            )
-            .catch(reject);
-    });
+  return new Promise((resolve, reject) => {
+    http
+      .get(`/api/client/servers/${uuid}`)
+      .then(({ data }) =>
+        resolve([
+          rawDataToServerObject(data),
+          // eslint-disable-next-line camelcase
+          data.meta?.is_server_owner ? ['*'] : data.meta?.user_permissions || [],
+        ])
+      )
+      .catch(reject);
+  });
 };

--- a/resources/scripts/blueprint/extends/routers/ServerRouter.tsx
+++ b/resources/scripts/blueprint/extends/routers/ServerRouter.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { NavLink, Route, Switch, useRouteMatch } from 'react-router-dom';
 import TransitionRouter from '@/TransitionRouter';
 import PermissionRoute from '@/components/elements/PermissionRoute';
@@ -12,6 +12,30 @@ import { ServerContext } from '@/state/server';
 import routes from '@/routers/routes';
 import blueprintRoutes from './routes';
 
+const blueprintExtensions = [...new Set(blueprintRoutes.server.map((route) => route.identifier))];
+
+/**
+ * Get the route egg IDs for each extension with server routes.
+ */
+const useExtensionEggs = () => {
+  const [extensionEggs, setExtensionEggs] = useState<{ [x: string]: string[] }>(
+    blueprintExtensions.reduce((prev, current) => ({ ...prev, [current]: ['-1'] }), {})
+  );
+
+  useEffect(() => {
+    (async () => {
+      const newEggs: { [x: string]: string[] } = {};
+      for (const id of blueprintExtensions) {
+        const resp = await fetch(`/api/client/extensions/blueprint/eggs?${new URLSearchParams({ id })}`);
+        newEggs[id] = (await resp.json()) as string[];
+      }
+      setExtensionEggs(newEggs);
+    })();
+  }, []);
+
+  return extensionEggs;
+};
+
 export const NavigationLinks = () => {
   const rootAdmin = useStoreState((state) => state.user.data!.rootAdmin);
   const serverEgg = ServerContext.useStoreState((state) => state.server.data?.BlueprintFramework.eggId);
@@ -22,10 +46,11 @@ export const NavigationLinks = () => {
     }
     return `${(url ? match.url : match.path).replace(/\/*$/, '')}/${value.replace(/^\/+/, '')}`;
   };
+  const extensionEggs = useExtensionEggs();
+  console.log(serverEgg);
 
   return (
     <>
-
       {/* Pterodactyl routes */}
       {routes.server
         .filter((route) => !!route.name)
@@ -41,29 +66,31 @@ export const NavigationLinks = () => {
               {route.name}
             </NavLink>
           )
-        )
-      }
+        )}
 
       {/* Blueprint routes */}
-      {blueprintRoutes.server.length > 0 && blueprintRoutes.server
-        .filter((route) => !!route.name)
-        .filter((route) => route.adminOnly ? rootAdmin : true)
-        .filter((route) => route.eggs && serverEgg ? route.eggs.includes(serverEgg) : true )
-        .map((route) =>
-          route.permission ? (
-            <Can key={route.path} action={route.permission} matchAny>
-              <NavLink to={to(route.path, true)} exact={route.exact}>
+      {blueprintRoutes.server.length > 0 &&
+        blueprintRoutes.server
+          .filter((route) => !!route.name)
+          .filter((route) => (route.adminOnly ? rootAdmin : true))
+          .filter((route) =>
+            extensionEggs[route.identifier].includes('-1')
+              ? true
+              : extensionEggs[route.identifier].find((id) => id === serverEgg?.toString())
+          )
+          .map((route) =>
+            route.permission ? (
+              <Can key={route.path} action={route.permission} matchAny>
+                <NavLink to={to(route.path, true)} exact={route.exact}>
+                  {route.name}
+                </NavLink>
+              </Can>
+            ) : (
+              <NavLink key={route.path} to={to(route.path, true)} exact={route.exact}>
                 {route.name}
               </NavLink>
-            </Can>
-          ) : (
-            <NavLink key={route.path} to={to(route.path, true)} exact={route.exact}>
-              {route.name}
-            </NavLink>
-          )
-        )
-      }
-
+            )
+          )}
     </>
   );
 };
@@ -78,13 +105,13 @@ export const NavigationRouter = () => {
     }
     return `${(url ? match.url : match.path).replace(/\/*$/, '')}/${value.replace(/^\/+/, '')}`;
   };
+  const extensionEggs = useExtensionEggs();
 
   const location = useLocation();
   return (
     <>
       <TransitionRouter>
         <Switch location={location}>
-
           {/* Pterodactyl routes */}
           {routes.server.map(({ path, permission, component: Component }) => (
             <PermissionRoute key={path} permission={permission} path={to(path)} exact>
@@ -95,17 +122,21 @@ export const NavigationRouter = () => {
           ))}
 
           {/* Blueprint routes */}
-          {blueprintRoutes.server.length > 0 && blueprintRoutes.server
-            .filter((route) => route.adminOnly ? rootAdmin : true)
-            .filter((route) => route.eggs && serverEgg ? route.eggs.includes(serverEgg) : true )
-            .map(({ path, permission, component: Component }) => (
-              <PermissionRoute key={path} permission={permission} path={to(path)} exact>
-                <Spinner.Suspense>
-                  <Component />
-                </Spinner.Suspense>
-              </PermissionRoute>
-            ))
-          }
+          {blueprintRoutes.server.length > 0 &&
+            blueprintRoutes.server
+              .filter((route) => (route.adminOnly ? rootAdmin : true))
+              .filter((route) =>
+                extensionEggs[route.identifier].includes('-1')
+                  ? true
+                  : extensionEggs[route.identifier].find((id) => id === serverEgg?.toString())
+              )
+              .map(({ path, permission, component: Component }) => (
+                <PermissionRoute key={path} permission={permission} path={to(path)} exact>
+                  <Spinner.Suspense>
+                    <Component />
+                  </Spinner.Suspense>
+                </PermissionRoute>
+              ))}
 
           <Route path={'*'} component={NotFound} />
         </Switch>

--- a/resources/scripts/blueprint/extends/routers/routes.ts
+++ b/resources/scripts/blueprint/extends/routers/routes.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 /* blueprint/import */
 
-interface RouteDefinition { 
+interface RouteDefinition {
   path: string;
   name: string | undefined;
   component: React.ComponentType;
@@ -12,7 +12,6 @@ interface RouteDefinition {
 }
 interface ServerRouteDefinition extends RouteDefinition {
   permission: string | string[] | null;
-  eggs?: number[];
 }
 interface Routes {
   account: RouteDefinition[];

--- a/resources/views/blueprint/admin/template.blade.php
+++ b/resources/views/blueprint/admin/template.blade.php
@@ -55,6 +55,19 @@
                 <p class="text-muted small">Allow this extension to extend the dashboard's blade wrapper.</p>
               </div>
             </div>
+
+            <div class="row">
+              <div class="col-xs-12">
+                <label class="control-label">Route eggs</label>
+                <select multiple class="pOptions form-control" name="{{ $EXTENSION_ID }}_eggs[]">
+                  <option value="-1" @if(in_array('-1', json_decode($blueprint->dbGet('blueprint', 'extensionconfig_'.$EXTENSION_ID.'_eggs') ?: '["-1"]'))) selected @endif>Show on all eggs</option>
+                  @foreach ($eggs as $egg)
+                    <option value="{{ $egg->id }}" @if(in_array(strval($egg->id), json_decode($blueprint->dbGet('blueprint', 'extensionconfig_'.$EXTENSION_ID.'_eggs') ?: '["-1"]'))) selected @endif>{{ $egg->name }}</option>
+                  @endforeach
+                </select>
+                <p class="text-muted small">Guess</p>
+              </div>
+            </div>
           </div>
 
           <div class="modal-footer" style="border-color:transparent; border-radius:7px">
@@ -74,4 +87,20 @@
       </div>
     </div>
   </div>
+@endsection
+
+@section('footer-scripts')
+  @parent
+  <script>
+    $('.pOptions').select2();
+  </script>
+  <style>
+    .select2-selection {
+      border-radius: 6px !important;
+    }
+    .select2-container--open .select2-selection {
+      border-bottom-left-radius: 0px !important;
+      border-bottom-right-radius: 0px !important;
+    }
+  </style>
 @endsection

--- a/routes/blueprint/client.php
+++ b/routes/blueprint/client.php
@@ -1,5 +1,7 @@
 <?php
 
+use Pterodactyl\BlueprintFramework\Controllers\ExtensionRouteController;
+
 foreach (File::allFiles(__DIR__ . '/client') as $partial) {
   if ($partial->getExtension() == 'php') {
     Route::prefix('/'.basename($partial->getFilename(), '.php'))
@@ -7,3 +9,8 @@ foreach (File::allFiles(__DIR__ . '/client') as $partial) {
     );
   }
 }
+
+/* Routes internally used by Blueprint. */
+Route::prefix('/blueprint')->group(function () {
+  Route::get('/eggs', [ExtensionRouteController::class, 'eggs']);
+});


### PR DESCRIPTION
saved as a JSON array of egg IDs in `blueprint::extensionconfig_[id]_eggs`.
ID of `-1` means the routes should be shown on all eggs