### PR TITLE
Fixed bad exit code

### DIFF
--- a/blueprint.sh
+++ b/blueprint.sh
@@ -284,7 +284,7 @@ if [[ $1 != "-bash" ]]; then
     dbAdd "blueprint.setupFinished"
     # Let the panel know the user has finished installation.
     sed -i "s/NOTINSTALLED/INSTALLED/g" $FOLDER/app/BlueprintFramework/Services/PlaceholderService/BlueprintPlaceholderService.php
-    exit 1
+    exit 0
   fi
 fi
 


### PR DESCRIPTION
In Bash, code 0 is success, non-zero is failure. In the meantime I've added || true to the end of the call to blueprint.sh so the Docker image can build, but changing this to 0 is cleaner.